### PR TITLE
Added missing 'img' to example code

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
 			<h5>HTML:</h5>
 
 <pre><code class="html">&lt;div class="photoset-grid-basic" data-layout="12"&gt;
-  &lt;src="img/demo/nyc1-500px.jpg" data-highres="img/demo/nyc1-highres.jpg"&gt;
-  &lt;src="img/demo/nyc2-500px.jpg" data-highres="img/demo/nyc2-highres.jpg"&gt;
-  &lt;src="img/demo/nyc3-500px.jpg" data-highres="img/demo/nyc3-highres.jpg"&gt;
+  &lt;img src="img/demo/nyc1-500px.jpg" data-highres="img/demo/nyc1-highres.jpg"&gt;
+  &lt;img src="img/demo/nyc2-500px.jpg" data-highres="img/demo/nyc2-highres.jpg"&gt;
+  &lt;img src="img/demo/nyc3-500px.jpg" data-highres="img/demo/nyc3-highres.jpg"&gt;
 &lt;/div&gt;</code></pre>
 
 			<h5>Javascript:</h5>
@@ -84,9 +84,9 @@
 			<h5>HTML:</h5>
 
 <pre><code class="html">&lt;div class="photoset-grid-custom" style="visibility: hidden;"&gt;
-  &lt;src="img/demo/print1-500px.jpg" data-highres="img/demo/print1-highres.jpg"&gt;
-  &lt;src="img/demo/print2-500px.jpg" data-highres="img/demo/print2-highres.jpg"&gt;
-  &lt;src="img/demo/print3-500px.jpg" data-highres="img/demo/print3-highres.jpg"&gt;
+  &lt;img src="img/demo/print1-500px.jpg" data-highres="img/demo/print1-highres.jpg"&gt;
+  &lt;img src="img/demo/print2-500px.jpg" data-highres="img/demo/print2-highres.jpg"&gt;
+  &lt;img src="img/demo/print3-500px.jpg" data-highres="img/demo/print3-highres.jpg"&gt;
 &lt;/div&gt;</code></pre>
 
 			<h5>Javascript:</h5>
@@ -126,11 +126,11 @@
 			<h5>HTML:</h5>
 
 <pre><code class="html">&lt;div class="photoset-grid-lightbox" data-layout="131" style="visibility: hidden;"&gt;
-  &lt;src="img/demo/withhearts1-500px.jpg" data-highres="img/demo/withhearts1-highres.jpg"&gt;
-  &lt;src="img/demo/withhearts2-500px.jpg" data-highres="img/demo/withhearts2-highres.jpg"&gt;
-  &lt;src="img/demo/withhearts3-500px.jpg" data-highres="img/demo/withhearts3-highres.jpg"&gt;
-  &lt;src="img/demo/withhearts4-500px.jpg" data-highres="img/demo/withhearts4-highres.jpg"&gt;
-  &lt;src="img/demo/withhearts5-500px.jpg" data-highres="img/demo/withhearts5-highres.jpg"&gt;
+  &lt;img src="img/demo/withhearts1-500px.jpg" data-highres="img/demo/withhearts1-highres.jpg"&gt;
+  &lt;img src="img/demo/withhearts2-500px.jpg" data-highres="img/demo/withhearts2-highres.jpg"&gt;
+  &lt;img src="img/demo/withhearts3-500px.jpg" data-highres="img/demo/withhearts3-highres.jpg"&gt;
+  &lt;img src="img/demo/withhearts4-500px.jpg" data-highres="img/demo/withhearts4-highres.jpg"&gt;
+  &lt;img src="img/demo/withhearts5-500px.jpg" data-highres="img/demo/withhearts5-highres.jpg"&gt;
 &lt;/div&gt;</code></pre>
 
 			<h5>Javascript:</h5>


### PR DESCRIPTION
The examples incorrectly uses a &lt;src&gt; tag. This patch fixes that.
