### PR TITLE
Passes element to onComplete callback.

### DIFF
--- a/jquery.photoset-grid.js
+++ b/jquery.photoset-grid.js
@@ -56,9 +56,9 @@
         
       },
 
-      _callback: function(){
+      _callback: function(elem){
         // Call the optional onComplete event after the plugin has been completed
-        this.options.onComplete();
+        this.options.onComplete(elem);
       },
 
       _setupRows: function(  elem, options ){
@@ -236,7 +236,7 @@
           setupStyles();
 
           // Call _callback which calls the optional onComplete
-          $this._callback();
+          $this._callback(elem);
         });
       }
 


### PR DESCRIPTION
It gives us two things:
1. Performance boost if we want to perform actions on the element (as we don't need to search for that element again).
2. Ability to perform actions on individual elements if we have several galleries on the page (the onComplete call is called for each gallery).

I was missing this functionality so I went ahead and implemented it. Ping me, If you need examples where this could be applied.
